### PR TITLE
Make brace matching for 'captures' lazy

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -602,7 +602,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\$)(\{(?:(private|script|global):)?.+\}))</string>
+					<string>(?i:(\$)(\{(?:(private|script|global):)?.+?\}))</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Greedy pattern was causing issues in single line scriptblocks
where string interpolation with braces is used

i.e. if ($true) { "${Env:\Foo}" }
