### PR TITLE
Make brace matching for 'captures' lazy

### DIFF
--- a/Support/PowershellSyntax.JSON-tmLanguage
+++ b/Support/PowershellSyntax.JSON-tmLanguage
@@ -382,7 +382,7 @@
 							"name": "storage.modifier.scope.powershell"
 						}
 					},
-					"match": "(?i:(\\$)(\\{(?:(private|script|global):)?.+\\}))"
+					"match": "(?i:(\\$)(\\{(?:(private|script|global):)?.+?\\}))"
 				}
 			]
 		}


### PR DESCRIPTION
Greedy pattern was causing issues in single line scriptblocks
where string interpolation with braces is used

An example of where this applies: 

``` powershell
if ($true) { "${Env:\Foo}" }
```
