### PR TITLE
Improperly comments lines with parameters containing # in command mode

### DIFF
--- a/Support/PowershellSyntax.JSON-tmLanguage
+++ b/Support/PowershellSyntax.JSON-tmLanguage
@@ -23,7 +23,7 @@
 			]
 		},
 		{
-			"begin": "#",
+			"begin": "(^|[^-\\])#",
 			"end": "$",
 			"name": "comment.line.powershell",
 			"patterns": [

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -45,7 +45,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#</string>
+			<string>(^|[^-\\])#</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>


### PR DESCRIPTION
Take for instance, this command line for Curl

``` powershell
&curl -# -G -k -L $url -o $fileName 2>&1 > "$script:log"
```

Everything after the # is treated as a comment.  However, these are parameters.
