### PR TITLE
This fixes Issue #4

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -602,7 +602,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?i:(\$)(\{(?:(private|script|global):)?.+\}))</string>
+					<string>(?i:(\$)(\{(?:(private|script|global):)?[^}]+\}))</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
RegEx grabs as much realestate as possible, especially when matching any
(.) character.  For this particular match, we only need all characters
that aren't closing curly brackets ([^}]).

Not sure why this commit shows the whole file changed, my git only shows the change in line 605:
http://i.imgur.com/Suu4C.png
