### PR TITLE
Update Support/PowershellSyntax.JSON-tmLanguage

### DIFF
--- a/Support/PowershellSyntax.JSON-tmLanguage
+++ b/Support/PowershellSyntax.JSON-tmLanguage
@@ -382,7 +382,7 @@
 							"name": "storage.modifier.scope.powershell"
 						}
 					},
-					"match": "(?i:(\\$)(\\{(?:(private|script|global):)?.+?\\}))"
+					"match": "(?i:(\\$)(\\{(?:(private|script|global):)?[^}]+(?=\\})\\}))"
 				}
 			]
 		}


### PR DESCRIPTION
This fixes Issue #4 on Win7 Ent x64 and OS X 10.6.8. Not tested on other systems.

This change ends a curly-bracket-variable by looking for any non-closing curly bracket character assuming there's an ending curly bracket available.

This improves the fix issued in #7.  Using the any character `.` causes it (in certain circumstances; I can provide examples if requested) to continue selection indefinitely. The modification that I've made causes the variable to end at the next curly bracket every time.
