### PR TITLE
Removing BOM.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-﻿# encoding: utf-8
+# encoding: utf-8
 
 PACKAGE_VERSION = "11.12.2011"
 


### PR DESCRIPTION
`setup.py` is using UTF8 with BOM encoding which is causing package load errors on some machines. Should fix #22
