### PR TITLE
removed `$` from end tag of single-quote here-string

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -207,7 +207,7 @@
 			<key>begin</key>
 			<string>@'\n</string>
 			<key>end</key>
-			<string>^'@$</string>
+			<string>^'@</string>
 			<key>name</key>
 			<string>string.quoted.single.heredoc.powershell</string>
 			<key>patterns</key>


### PR DESCRIPTION
Single quoted here-strings were still not displaying correctly. I forgot to remove the `$` from the end tag when I removed it from the start tag in the previous [commit](https://github.com/william-voyek/PowerShell/commit/ee44ce8f865149c4ec2292ba6ab2f6186b58a2d7)
