### PR TITLE
Fix for #53. Exclude short parameter block from function declaration capturing

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -508,7 +508,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\{</string>
+			<string>\{|\(</string>
 		</dict>
 		<key>interpolatedStringContent</key>
 		<dict>


### PR DESCRIPTION
PowerShell support two param block declarations.

``` powershell
function foo($arg) {} # this is a short form

function bar { params($arg) } # this is a long form
```

We should capture short form args just as any other block.
