### PR TITLE
Update PowershellSyntax.tmLanguage

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -238,7 +238,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?&lt;!\.)(?i:begin|break|catch|class|continue|data|define|do|dynamicparam|else|elseif|end|exit|filter|finally|for|foreach(?!=-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|while|workflow)\b</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|class|continue|data|define|do|dynamicparam|else|elseif|end|exit|filter|finally|for|foreach(?!=-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where|while|workflow)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>
@@ -250,7 +250,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains)|replace))\b</string>
+			<string>-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains)|replace))(?!\p{L})</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.powershell</string>
 		</dict>
@@ -268,13 +268,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-(?i:band|bor|bnot|bxor)\b</string>
+			<string>-(?i:band|bor|bnot|bxor)(?!\p{L})</string>
 			<key>name</key>
 			<string>keyword.operator.bitwise.powershell</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-f\b</string>
+			<string>-(?i:f)(?!\p{L})</string>
 			<key>name</key>
 			<string>keyword.operator.string-format.powershell</string>
 		</dict>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -226,13 +226,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-([lg][te]|[ci]?(eq|ne))</string>
+			<string>-([ci]?[lg][te]|eq|ne)</string>
 			<key>name</key>
 			<string>keyword.operator.logical.powershell</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:[a-z][a-z0-9]+-?[a-z][a-z0-9]+)(?i:\.(?:exe|cmd|bat|ps1))</string>
+			<string>(?i:\S+)(?i:\.(?:exe|cmd|bat|ps1))</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>
@@ -256,13 +256,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-(?i:join|split)|!</string>
+			<string>-(?i:join|split)(?!\p{L})|!</string>
 			<key>name</key>
 			<string>keyword.operator.unary.powershell</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-(?i:and|or|not|xor)|!</string>
+			<string>-(?i:and|or|not|xor)(?!\p{L})|!</string>
 			<key>name</key>
 			<string>keyword.operator.logical.powershell</string>
 		</dict>
@@ -390,7 +390,7 @@
 			<key>comment</key>
 			<string>Verb-Noun pattern:</string>
 			<key>match</key>
-			<string>(?:[a-zA-Z.]*\\)?(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)\-.+?(?:\.(?:exe|cmd|bat|ps1))?\b</string>
+			<string>(?:(\p{L}|\d|_|-|\\|\:)*\\)?\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)\-.+?(?:\.(?:exe|cmd|bat|ps1))?\b</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -250,7 +250,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains)|replace))(?!\p{L})</string>
+			<string>-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains|in)|replace))(?!\p{L})</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.powershell</string>
 		</dict>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -238,7 +238,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|class|continue|data|define|do|dynamicparam|else|elseif|end|exit|filter|finally|for|foreach(?!=-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where|while|workflow)|%|\?)(?!\w)</string>
+			<string>(?&lt;!\w)((?i:begin|break|catch|class|continue|data|define|do|dynamicparam|else|elseif|end|exit|filter|finally|for|foreach(?!=-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while|workflow)|%|\?)(?!\w)</string>
 			<key>name</key>
 			<string>keyword.control.powershell</string>
 		</dict>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -232,7 +232,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\S+)(?i:\.(?:exe|cmd|bat|ps1))</string>
+			<string>(?i:(\S&&[^<>"/\|?*])+)(?i:\.(?:exe|cmd|bat|ps1))</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>


### PR DESCRIPTION
Fixes several issues:
**229**: Correctly highlights the operators ```-clt```, ```-cle```, ```-cgt```, ```-cge```
**235**: Fixes issues highlighting paths with symbols in them
**259** & **265**: Fixes issues with operator highlighting, such as ```-NoTypeInformation``` being incorrectly highlighted as two elements, but allows for ```-Not1``` to be correctly interpreted as two elements
**393**: Allows for permissible symbols in command names