### PR TITLE
Revert to the version 2.0.0 'foo.exe' reconginition. Fix for #87 and #95

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -240,7 +240,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:([\S&amp;&amp;[^&lt;&gt;"/\|?*]])+)(?i:\.(?i:exe|cmd|bat|ps1))</string>
+			<string>(?i:[a-z][a-z0-9]+-?[a-z][a-z0-9]+)(?i:\.(?i:exe|cmd|bat|ps1))</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -55,9 +55,14 @@ function Get-MemberSignature {
     }
 }
 
+foo "$(x).exe"
+
 function echo([string]$text) {
     write-host $text
 }
+
+$file = join-path $env:SystemDrive "$([System.io.path]::GetRandomFileName()).ps1"
+$ScriptBlock | Out-File $file -Force
 
 # declarations should be consistent
 function foo.bar() {}


### PR DESCRIPTION
I cannot figure out why it broke interpolation, but this is a pretty unusual syntax. Let's avoid it.