### PR TITLE
Fix function highligting

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -522,7 +522,7 @@
 		<key>function</key>
 		<dict>
 			<key>begin</key>
-			<string>((?i:function|filter|configuration|workflow))\s+((?:\p{L}|\d|_|-|\.)+)</string>
+			<string>(?&lt;!\S)((?i:function|filter|configuration|workflow))\s+((?:\p{L}|\d|_|-|\.)+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -538,7 +538,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function</string>
+					<string>entity.name.function.powershell</string>
 				</dict>
 			</dict>
 			<key>end</key>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -522,7 +522,7 @@
 		<key>function</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!\S)((?i:function|filter|configuration|workflow))\s+((?:\p{L}|\d|_|-|\.)+)</string>
+			<string>(?&lt;!\S)(?i)(function|filter|configuration|workflow)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -536,6 +536,11 @@
 					<string>storage.type</string>
 				</dict>
 				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.scope.powershell</string>
+				</dict>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.function.powershell</string>

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -473,3 +473,10 @@ function Get-EscapedPath
         return $path
     }
 }
+
+#TODO: "function" should not be highlighted inside a command:
+#      These three should highlight roughly the same:
+Test-Highlight -Something StringValue
+Test-Highlight -TestFunction StringValue
+Test-Function -Function FunctionName
+Move-Item .\AFolderNamedFunction .\ANew\Location

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -477,6 +477,12 @@ function Get-EscapedPath
 #TODO: "function" should not be highlighted inside a command:
 #      These three should highlight roughly the same:
 Test-Highlight -Something StringValue
+Move-Item .\AFolderForWorkflow .\ANew\Location
+Test-Function -StringFilter Pattern
 Test-Highlight -TestFunction StringValue
-Test-Function -Function FunctionName
-Move-Item .\AFolderNamedFunction .\ANew\Location
+function Test-Thing { <# When broken, only this comment wasn't broken #> }
+
+# TODO: we should support scope on function names
+function global:Test-Thing { Get-Command $global:VariableName }
+function local:Test-Thing { Get-Command $global:VariableName }
+function script:Test-Thing { Get-Command $global:VariableName }


### PR DESCRIPTION
This fixes a longstanding bug highlighting code like:

```posh
# This is ok
Test-Highlight -Something StringValue
# This is not
Test-Highlight -TestFunction StringValue
# and it breaks this:
Test-Highlight -Something StringValue
```

I also fixed _scope_ on function names, like:

```posh
function Test-Thing { Get-Command $VariableName }
# the function name should be highlighted as above, and both "global"s should be the same...
function global:Test-Thing { Get-Command $global:VariableName }
Function LOCAL:Test-Thing { Get-Command $local:VariableName }
FUNCTION script:Test-Thing { Get-Command $script:VariableName }
```