### PR TITLE
Fix #139 Where-Object

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -7,6 +7,8 @@
 		<string>ps1</string>
 		<string>psm1</string>
 		<string>psd1</string>
+ 		<string>pssc</string>
+f		<string>psrc</string>
 	</array>
 	<key>name</key>
 	<string>PowerShell</string>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -67,6 +67,12 @@
 			<string>keyword.operator.redirection.powershell</string>
 		</dict>
 		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)(?i)(begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?=\s*\()|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|while)(?!\w)</string>
+			<key>name</key>
+			<string>keyword.control.powershell</string>
+		</dict>
+		<dict>
 			<key>include</key>
 			<string>#commands</string>
 		</dict>
@@ -245,12 +251,6 @@
 			<string>(?i:[a-z][a-z0-9]+-?[a-z][a-z0-9]+)(?i:\.(?i:exe|cmd|bat|ps1))</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
-			<key>name</key>
-			<string>keyword.control.powershell</string>
 		</dict>
 		<dict>
 			<key>captures</key>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -7,7 +7,7 @@
 		<string>ps1</string>
 		<string>psm1</string>
 		<string>psd1</string>
- 		<string>pssc</string>
+		<string>pssc</string>
 		<string>psrc</string>
 	</array>
 	<key>name</key>
@@ -414,9 +414,17 @@
 			<array>
 				<dict>
 					<key>comment</key>
+					<string>Applications:</string>
+					<key>match</key>
+					<string>(?i)(?&lt;=\s|\||^|;)(\p{L}|\d|_|-|\\|\:|\.)*\.(?:exe|cmd|bat|ps1|py|js|vbs|wsf|com|msc|cpl)\b</string>
+					<key>name</key>
+					<string>support.function.application</string>
+				</dict>				
+				<dict>
+					<key>comment</key>
 					<string>Verb-Noun pattern:</string>
 					<key>match</key>
-					<string>(?:(\p{L}|\d|_|-|\\|\:)*\\)?\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)\-.+?(?:\.(?i:exe|cmd|bat|ps1))?\b</string>
+					<string>(?:(\p{L}|\d|_|-|\\|\:)*\\)?\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)\-(\p{L}|\d|_|-)+?\b</string>
 					<key>name</key>
 					<string>support.function.powershell</string>
 				</dict>
@@ -424,7 +432,7 @@
 					<key>comment</key>
 					<string>Builtin cmdlets with reserved verbs</string>
 					<key>match</key>
-					<string>(?&lt;!\w)(?i:foreach-object)(?!\w)</string>
+					<string>(?&lt;=\s|\||^|;)(?:(?i:foreach|where|sort|tee)(?:-object)?|%|\?)\b</string>
 					<key>name</key>
 					<string>support.function.powershell</string>
 				</dict>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -8,7 +8,7 @@
 		<string>psm1</string>
 		<string>psd1</string>
  		<string>pssc</string>
-f		<string>psrc</string>
+		<string>psrc</string>
 	</array>
 	<key>name</key>
 	<string>PowerShell</string>

--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -432,7 +432,7 @@
 					<key>comment</key>
 					<string>Builtin cmdlets with reserved verbs</string>
 					<key>match</key>
-					<string>(?&lt;=\s|\||^|;)(?:(?i:foreach|where|sort|tee)(?:-object)?|%|\?)\b</string>
+					<string>(?&lt;=\s|\||^|;)(?:(?i:foreach|where|sort|tee)(?i:-object)?|%|\?)\b</string>
 					<key>name</key>
 					<string>support.function.powershell</string>
 				</dict>

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -330,9 +330,17 @@ do {
 
 }
 
+# foreach statement
 foreach($item in get-childitem) {
-
+    remove-item $item -whatif
 }
+
+# where and foreach are COMMANDS here
+# They should be highlighted the same as get-childitem
+get-childitem | where | foreach {
+    remove-item $_ -whatif
+}
+
 
 for($i = 0; $i -lt 10; $i++) {
 

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -288,11 +288,12 @@ $a = $("Guess what, happens ""here, hey""" | "Hm... $("this, is" strange.) you c
 # file ext shouldn't be styled as numeric
 # TODO: the whole file name really ought to be styled as a command *sigh*
 this-isnot.ps1
+.\path\to\this.ps1
 # FIXME:
 a_mistake.here.ps1
 "anothermistake.ps1"
 # FIXME:
-notepad.exe
+notepad.exe;notepad.exe;
 # TODO: file ext shouldn't be styled as numeric, even if it's short:
 get-content test.1
 
@@ -337,9 +338,28 @@ foreach($item in get-childitem) {
 
 # where and foreach are COMMANDS here
 # They should be highlighted the same as get-childitem
-get-childitem | where | foreach {
+get-childitem | where-object { $true } | foreach-object {
     remove-item $_ -whatif
 }
+# The short forms of them should be highlighted correctly too, they're special
+get-childitem |where { $true } |foreach {
+    remove-item $_ -whatif
+}
+get-childitem|where { $true }|foreach {
+    remove-item $_ -whatif
+}
+get-childitem | ? { $true } | % {
+    remove-item $_ -whatif
+}
+get-childitem|?{ $true }|%{
+    remove-item $_ -whatif
+}
+# Just to be sure, lets use where and foreach in places they shouldn't get highlighted
+Test-Highlight -Somewhere StringForEach
+Test-Highlight .\AFolderSomewhere .\ANew\ForEach\Folder\Where\Things
+Something.exe -Where Pattern
+Test-Highlight -ForEach StringValue
+
 
 
 for($i = 0; $i -lt 10; $i++) {
@@ -351,7 +371,7 @@ get-item $()
 if (10 -cgt 100) { }
 $a -is $b
 $b -contains $c
-$x -notcontains $c
+$x -notcontains $c 
 $a -match $b
 $a -notmatch $b
 $x -like $c

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -505,6 +505,7 @@ function Get-EscapedPath
 #      These three should highlight roughly the same:
 Test-Highlight -Something StringValue
 Move-Item .\AFolderForWorkflow .\ANew\Location
+Get-WMIObject Win32_NetworkAdapterConfiguration
 Test-Function -StringFilter Pattern
 Test-Highlight -TestFunction StringValue
 function Test-Thing { <# When broken, only this comment wasn't broken #> }

--- a/tests/samples/test-file.ps1
+++ b/tests/samples/test-file.ps1
@@ -486,10 +486,9 @@ function Get-EscapedPath
     param( 
     [Parameter(
         Position=0, 
-        Mandatory=$true
+        Mandatory=$true,
         ValueFromPipeline=$true,
-        ValueFromPipelineByPropertyName=$true)
-    ]
+        ValueFromPipelineByPropertyName=$true)]
     [string]$path
     ) 
 


### PR DESCRIPTION
Fix syntax highlighting for Where-Object
https://github.com/SublimeText/PowerShell/issues/139

Along the line I actually fixed highlighting for all commands (application paths, etc) and even prevented highlighting where they shouldn't be highlighted.
