### PR TITLE
Partial fix for function attribute highlighting

### DIFF
--- a/Support/PowershellSyntax.tmLanguage
+++ b/Support/PowershellSyntax.tmLanguage
@@ -394,7 +394,7 @@
 							<key>comment</key>
 							<string>really we should match the known attributes first</string>
 							<key>match</key>
-							<string>(\w+)\s*=?([^"']*?|'[^']*?'|"[^"]*?")?(?=,|\))</string>
+							<string>((\w+)\s*=?)?([^"']*?|'[^']*?'|"[^"]*?")?(?=,|\))</string>
 							<key>name</key>
 							<string>entity.other.attribute-name.powershell</string>
 						</dict>


### PR DESCRIPTION
This change will now allow syntax highlighting to continue after
encountering a somewhat complex regular expression in a ValidateSet()
attribute, but with the side effect that value pairs in a Parameter()
block now only have the first pair correctly highlited.
