### PR TITLE
Use pwsh as cmd on non-Windows platforms

### DIFF
--- a/Support/Powershell.sublime-build
+++ b/Support/Powershell.sublime-build
@@ -1,4 +1,8 @@
 {
-	"cmd": ["powershell.exe", "-noprofile", "-file", "$file"],
-	"selector": "source.powershell"
+    "cmd": ["pwsh", "-noprofile", "-file", "$file"],
+    "selector": "source.powershell",
+
+    "windows": {
+        "cmd": ["powershell.exe", "-noprofile", "-file", "$file"],
+    }
 }


### PR DESCRIPTION
`powershell.exe` is only provided by Windows PowerShell, PSCore (ie non-Windows) uses `pwsh`. 

This means that the build system is currently unusable outside of Windows Powershell, without symlinking pwsh to powershell.exe or similar.

Discussion of naming: https://github.com/PowerShell/PowerShell/issues/4214#issuecomment-335989245