### PR TITLE
Changing default encoding to UTF-8 with BOM

### DIFF
--- a/Snippets/env.sublime-snippet
+++ b/Snippets/env.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[#!/usr/bin/env ${1:pwsh}]]></content>
+    <tabTrigger>!env</tabTrigger>
+    <scope>source.powershell</scope>
+    <description>#!/usr/bin/env</description>
+</snippet>

--- a/Support/PowershellSyntax.sublime-settings
+++ b/Support/PowershellSyntax.sublime-settings
@@ -1,4 +1,5 @@
 {
 	"word_wrap": false,
-	"translate_tabs_to_spaces": true
+	"translate_tabs_to_spaces": true,
+	"default_encoding": "UTF-8 with BOM"
 }


### PR DESCRIPTION
Changing default encoding to UTF-8 with BOM to enable support for special characters such as åäö in Windows Powershell.

This is necessary unless UTF-8 is enabled in Windows which is off by default.