### PR TITLE
Removed "word_wrap": false

### DIFF
--- a/Support/PowershellSyntax.sublime-settings
+++ b/Support/PowershellSyntax.sublime-settings
@@ -1,4 +1,3 @@
 {
-	"word_wrap": false,
 	"translate_tabs_to_spaces": true
 }


### PR DESCRIPTION
The user should have the freedom whether he wants it to be `true` or `false` by specifying the setting in the global Preferences in Sublime Text