### PR TITLE
Add 'clean' block keyword to PowerShell.sublime-syntax

### DIFF
--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -102,6 +102,8 @@ contexts:
       scope: keyword.context.block.begin.powershell
     - match: \b(?i:end){{kebab_break}}
       scope: keyword.context.block.end.powershell
+    - match: \b(?i:clean){{kebab_break}}
+      scope: keyword.context.block.clean.powershell
     # Loops
     - match: \b(?i:for|foreach(?!-object)){{kebab_break}}
       scope: keyword.control.loop.for.powershell

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -1131,6 +1131,10 @@ catch { }
 # <- keyword.control
 #     ^ punctuation.section.braces.begin
 #       ^ punctuation.section.braces.end
+clean { }
+# <- keyword.context.block.clean
+#     ^ punctuation.section.braces.begin
+#       ^ punctuation.section.braces.end
 
 # Reserved words
 Configuration Crazyness {


### PR DESCRIPTION
This commit also adds tests for the new syntax. Fixes #181 .