### PR TITLE
Mark ambiguous float / long syntax as deprecated

### DIFF
--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -566,6 +566,24 @@ contexts:
             \b{{dec_digits}}
             (?:
               (?:
+                (?:(?:\.(?!\.))\d*)    # No `_` after the `.`
+                {{dec_exponent}}?
+              | {{dec_exponent}}
+              )
+             (?:{{integer_suffix}})
+            )
+          )
+          ({{bytes_unit}}\b)?
+        )
+      captures:
+        1: invalid.deprecated.powershell
+        2: keyword.other.unit.powershell
+    - match: |-
+        (?x:
+          (
+            \b{{dec_digits}}
+            (?:
+              (?:
                 (?:(\.(?!\.))\d*)    # No `_` after the `.`
                 {{dec_exponent}}?
               | {{dec_exponent}}

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -476,8 +476,14 @@ There is no @platting here!
     1.d
 #   ^^^ constant.numeric.float
     1.lGB
-#   ^^^ constant.numeric.float - unclear whether float or int
+#   ^^^ invalid.deprecated
 #      ^^ keyword.other.unit
+    1.2345e1LGB
+#   ^^^^^^^^^ invalid.deprecated
+#            ^^ keyword.other.unit
+    1.2345e-5LGB
+#   ^^^^^^^^^^ invalid.deprecated
+#             ^^ keyword.other.unit
     1.dGB
 #   ^^^ constant.numeric.float
 #      ^^ keyword.other.unit
@@ -524,7 +530,7 @@ There is no @platting here!
 #     ^ keyword.operator
     -10.002L
 #   ^ keyword.operator.unary
-#    ^^^^^^^ constant.numeric.float - unclear whether float or int
+#    ^^^^^^^ invalid.deprecated
     $x..5.40D
 #   ^ punctuation.definition.variable
 #   ^^ variable.other.readwrite


### PR DESCRIPTION
[Microsoft themselves warn against using that kind of notation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_numeric_literals?view=powershell-7.4).

Tests were changed to reflect the new designation. With this, the CI checks shouldn't return any more errors for now!

Thank you Michael and deathaxe for your help so far.