### PR TITLE
Add support for syntax-based folding

### DIFF
--- a/Fold.tmPreferences
+++ b/Fold.tmPreferences
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.powershell</string>
+    <key>settings</key>
+    <dict>
+        <key>foldScopes</key>
+        <array>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.section.block.begin</string>
+                <key>end</key>
+                <string>punctuation.section.block.end</string>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.definition.comment.block.begin</string>
+                <key>end</key>
+                <string>punctuation.definition.comment.block.end</string>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.definition.string.begin</string>
+                <key>end</key>
+                <string>punctuation.definition.string.end</string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>

--- a/Fold.tmPreferences
+++ b/Fold.tmPreferences
@@ -9,21 +9,41 @@
         <array>
             <dict>
                 <key>begin</key>
-                <string>punctuation.section.block.begin</string>
+                <string>meta.fold.begin</string>
                 <key>end</key>
-                <string>punctuation.section.block.end</string>
+                <string>meta.fold.end</string>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.definition.comment.block.begin</string>
                 <key>end</key>
                 <string>punctuation.definition.comment.block.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.definition.string.begin</string>
                 <key>end</key>
                 <string>punctuation.definition.string.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.section.group.begin</string>
+                <key>end</key>
+                <string>punctuation.section.group.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.section.braces.begin</string>
+                <key>end</key>
+                <string>punctuation.section.braces.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
         </array>
     </dict>

--- a/Fold.tmPreferences
+++ b/Fold.tmPreferences
@@ -23,9 +23,17 @@
             </dict>
             <dict>
                 <key>begin</key>
-                <string>punctuation.definition.string.begin</string>
+                <string>string.quoted.double.heredoc punctuation.definition.string.begin</string>
                 <key>end</key>
-                <string>punctuation.definition.string.end</string>
+                <string>string.quoted.double.heredoc punctuation.definition.string.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>string.quoted.single.heredoc punctuation.definition.string.begin</string>
+                <key>end</key>
+                <string>string.quoted.single.heredoc punctuation.definition.string.end</string>
                 <key>excludeTrailingNewlines</key>
                 <false/>
             </dict>

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -811,15 +811,17 @@ contexts:
         - include: comment-line
 
   regions:
-    - match: ^(#region\s*(.*))$
+    - match: ^\s*(#)\s*(region)\b\s*(\S.*)
       captures:
-        # Applying the punctuation.section.block.begin scope to the entire pattern
-        # allows Sublime Text to show the region name when it is folded.
-        1: punctuation.section.block.begin.powershell comment.line.powershell
-        2: meta.toc-list.powershell
-    - match: ^#endregion\b
-      scope: punctuation.section.block.end.powershell comment.line.powershell
-      push:
-        - meta_content_scope: comment.line.powershell
-        - include: pop-at-newline
-        - include: comment-embedded-docs
+        1: punctuation.definition.comment.powershell
+        2: comment.line.powershell
+        3: meta.toc-list.powershell meta.fold.begin.powershell entity.name.section.powershell
+    - match: '^\s*(#)\s*(region)\b\s*'
+      captures:
+        1: punctuation.definition.comment.powershell
+        2: comment.line.powershell meta.fold.begin.powershell
+    - match: '^\s*(#)\s*(endregion\b[^\S\n]*.*)($\n?)'
+      captures:
+        1: punctuation.definition.comment.powershell
+        2: comment.line.powershell
+        3: meta.fold.end.powershell

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -35,6 +35,7 @@ contexts:
       pop: true
 
   main:
+    - include: regions
     - include: comments
     - include: expressions
 
@@ -808,3 +809,17 @@ contexts:
         - match: (?=\()
           pop: true
         - include: comment-line
+
+  regions:
+    - match: ^(#region\s*(.*))$
+      captures:
+        # Applying the punctuation.section.block.begin scope to the entire pattern
+        # allows Sublime Text to show the region name when it is folded.
+        1: punctuation.section.block.begin.powershell comment.line.powershell
+        2: meta.toc-list.powershell
+    - match: ^#endregion\b
+      scope: punctuation.section.block.end.powershell comment.line.powershell
+      push:
+        - meta_content_scope: comment.line.powershell
+        - include: pop-at-newline
+        - include: comment-embedded-docs

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -811,17 +811,16 @@ contexts:
         - include: comment-line
 
   regions:
-    - match: ^\s*(#)\s*(region)\b\s*(\S.*)
+    - match: ^\s*((#)\s*(region\b)(?:\s*(\S.*))?(\n?))
       captures:
-        1: punctuation.definition.comment.powershell
-        2: comment.line.powershell
-        3: meta.toc-list.powershell meta.fold.begin.powershell entity.name.section.powershell
-    - match: '^\s*(#)\s*(region)\b\s*'
+        1: comment.line.powershell
+        2: punctuation.definition.comment.powershell
+        3: keyword.other.region.begin.powershell
+        4: meta.toc-list.powershell entity.name.section.powershell
+        5: meta.fold.begin.powershell
+    - match: ^\s*((#)\s*(endregion\b).*(\n?))
       captures:
-        1: punctuation.definition.comment.powershell
-        2: comment.line.powershell meta.fold.begin.powershell
-    - match: '^\s*(#)\s*(endregion\b[^\S\n]*.*)($\n?)'
-      captures:
-        1: punctuation.definition.comment.powershell
-        2: comment.line.powershell
-        3: meta.fold.end.powershell
+        1: comment.line.powershell
+        2: punctuation.definition.comment.powershell
+        3: keyword.other.region.end.powershell
+        4: meta.fold.end.powershell

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -1813,9 +1813,24 @@ function get-number {}
 
 #region Test
 #<- punctuation.definition.comment
-#^^^^^^ comment.line.powershell
-#       ^^^^ meta.toc-list meta.fold.begin entity.name.section
+#^^^^^^ keyword.other.region.begin
+#<- comment.line.powershell
+#       ^^^^ meta.toc-list entity.name.section
 #       @@@@ local-definition
-#endregion (Text after #endregion is optional, but the ISE marks it as a comment as well)
+#           ^ meta.fold.begin
+#endregion (More comments)
 #<- punctuation.definition.comment.powershell
-#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line
+#^^^^^^^^^ keyword.other.region.end.powershell
+#<- comment.line
+#                         ^ meta.fold.end
+
+#region
+#<- punctuation.definition.comment
+#^^^^^^ keyword.other.region.begin
+#<- comment.line.powershell
+#      ^ meta.fold.begin
+#endregion (More comments)
+#<- punctuation.definition.comment.powershell
+#^^^^^^^^^ keyword.other.region.end.powershell
+#<- comment.line
+#                         ^ meta.fold.end

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -1812,9 +1812,10 @@ function get-number {}
 #>
 
 #region Test
-#<- punctuation.section.block.begin comment.line
-#       ^^^^ meta.toc-list
+#<- punctuation.definition.comment
+#^^^^^^ comment.line.powershell
+#       ^^^^ meta.toc-list meta.fold.begin entity.name.section
 #       @@@@ local-definition
 #endregion (Text after #endregion is optional, but the ISE marks it as a comment as well)
-#<- punctuation.section.block.end comment.line
+#<- punctuation.definition.comment.powershell
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -469,6 +469,11 @@ There is no @platting here!
 "@
 # <- string.quoted.double.heredoc
  # <- string.quoted.double.heredoc
+@'
+#<- meta.string string.quoted.single.heredoc punctuation.definition.string.begin
+A 'single quoted' "heredoc"
+'@
+#<- meta.string string.quoted.single.heredoc punctuation.definition.string.end
 
 # Numeric constants
 
@@ -1805,3 +1810,11 @@ function get-number {}
 #<- comment.block comment.documentation.embedded punctuation.definition.keyword.documentation
 #^^^^^^^^^^^^ keyword.other.documentation
 #>
+
+#region Test
+#<- punctuation.section.block.begin comment.line
+#       ^^^^ meta.toc-list
+#       @@@@ local-definition
+#endregion (Text after #endregion is optional, but the ISE marks it as a comment as well)
+#<- punctuation.section.block.end comment.line
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line


### PR DESCRIPTION
Regions, comment blocks, and heredocs can now be folded. Additionally, region names are now searchable using ctrl-r.