### PR TITLE
Add support for long options in syntax

### DIFF
--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -186,7 +186,7 @@ contexts:
       captures:
         1: punctuation.definition.keyword.powershell
     # Flags/Options/Parameters
-    - match: \B([-/])\p{L}(?:[\w-]*\w)?
+    - match: \B(-|--|/)\p{L}(?:[\w-]*\w)?
       scope: variable.parameter.option.powershell
       captures:
         1: punctuation.definition.parameter.powershell

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -186,7 +186,7 @@ contexts:
       captures:
         1: punctuation.definition.keyword.powershell
     # Flags/Options/Parameters
-    - match: \B(-|--|/)\p{L}(?:[\w-]*\w)?
+    - match: \B(--?|[/+])\p{L}(?:[\w-]*\w)?
       scope: variable.parameter.option.powershell
       captures:
         1: punctuation.definition.parameter.powershell

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -92,6 +92,15 @@ throw "Do not run this file!"
 #                                     ^^^ keyword.control
 #                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted - constant - variable - comment
 
+& gnutool.exe -s 'short option' --long-option --very_long_option value
+#<- keyword.operator.other
+# ^^^^^^^^^^^ variable.function
+#             ^ variable.parameter.option punctuation.definition.parameter
+#              ^ variable.parameter.option
+#                               ^^ variable.parameter.option punctuation.definition.parameter
+#                                             ^^ variable.parameter.option punctuation.definition.parameter
+#                                               ^^^^^^^^^^^^^^^^ variable.parameter.option
+
 # Automatic variables
 $_, $$, $^, $?
 # <- punctuation.definition.variable

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -92,7 +92,7 @@ throw "Do not run this file!"
 #                                     ^^^ keyword.control
 #                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted - constant - variable - comment
 
-& gnutool.exe -s 'short option' --long-option --very_long_option value
+& gnutool.exe -s 'short option' --long-option --very_long_option value +plus-option
 #<- keyword.operator.other
 # ^^^^^^^^^^^ variable.function
 #             ^ variable.parameter.option punctuation.definition.parameter
@@ -100,6 +100,8 @@ throw "Do not run this file!"
 #                               ^^ variable.parameter.option punctuation.definition.parameter
 #                                             ^^ variable.parameter.option punctuation.definition.parameter
 #                                               ^^^^^^^^^^^^^^^^ variable.parameter.option
+#                                                                      ^ variable.parameter.option punctuation.definition.parameter
+#                                                                       ^^^^^^^^^^^ variable.parameter.option 
 
 # Automatic variables
 $_, $$, $^, $?


### PR DESCRIPTION
Tweak the regex which matches command options to correctly detect GNU-style long options.