### PR TITLE
Allow regions anywhere comments are permitted

### DIFF
--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -19,6 +19,7 @@ first_line_match: |-
 
 contexts:
   prototype:
+    - include: regions
     - include: comments
 
   main:
@@ -76,7 +77,6 @@ contexts:
   expressions-without-commands:
     # Meta
     - include: labels
-    - include: regions
     - include: requires-directives
 
     - include: escape-sequences
@@ -580,7 +580,7 @@ contexts:
     - meta_scope: meta.block.parameters.powershell
     - match: \)
       scope: punctuation.section.block.end.powershell
-      pop: 1
+      pop: 2
     - include: comma-separators
     - include: attributes
     - include: types-without-members

--- a/tests/syntax_test_PowerShell.ps1
+++ b/tests/syntax_test_PowerShell.ps1
@@ -2370,6 +2370,8 @@ $a3[1..2]
 #       ^^^^ meta.toc-list entity.name.section
 #       @@@@ local-definition
 #           ^ meta.fold.begin
+    Do-Stuff
+#   @@@@@@@@ reference
 #endregion (More comments)
 #<- punctuation.definition.comment.powershell
 #^^^^^^^^^ keyword.other.region.end.powershell
@@ -2386,3 +2388,55 @@ $a3[1..2]
 #^^^^^^^^^ keyword.other.region.end.powershell
 #<- comment.line
 #                         ^ meta.fold.end
+
+function Process-DeploymentConfig {
+#        @@@@@@@@@@@@@@@@@@@@@@@@ definition
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string]$ConfigJson,
+
+    [Parameter(Mandatory=$true)]
+    [hashtable]PathVariables
+  )
+
+  #region Helper function for path resolution
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.powershell
+# ^ punctuation.definition.comment
+#  ^^^^^^ keyword.other.region.begin
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.toc-list entity.name.section
+#         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
+#                                            ^ meta.fold.begin
+
+  function Resolve-ConfigPath {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.powershell meta.function.powershell
+# ^^^^^^^^ keyword.declaration.function.powershell
+#          ^^^^^^^^^^^^^^^^^^ entity.name.function.powershell
+#          @@@@@@@@@@@@@@@@@@ definition
+#                             ^ punctuation.section.block.begin.powershell
+    [CmdletBinding()]
+    param (
+      [Parameter(Mandatory=$true)]
+      [string]$Path,
+
+      [Parameter(Mandatory=$true)]
+      [hashtable]$PathVariables
+    )
+
+    $Private:ResolvedPath = $Path
+    foreach ($key in $PathVariables.Keys) {
+      $ResolvedPath = $ResolvedPath.Replace($key, $PathVariables[$key])
+#                                   @@@@@@@ reference
+    }
+    return $ResolvedPath
+  }
+  #endregion
+# ^^^^^^^^^^^ comment.line.powershell
+# ^ punctuation.definition.comment.powershell
+#  ^^^^^^^^^ keyword.other.region.end.powershell
+#           ^ meta.fold.end
+
+
+  Resolve-ConfigPath -Path "Foo" -PathVariables $PathVariables
+# @@@@@@@@@@@@@@@@@@ reference
+}

--- a/tests/syntax_test_PowerShell.ps1
+++ b/tests/syntax_test_PowerShell.ps1
@@ -2400,13 +2400,13 @@ function Process-DeploymentConfig {
     [hashtable]PathVariables
   )
 
-  #region Helper function for path resolution
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.powershell
+  #region PathHelper
+# ^^^^^^^^^^^^^^^^^^^ comment.line.powershell
 # ^ punctuation.definition.comment
 #  ^^^^^^ keyword.other.region.begin
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.toc-list entity.name.section
-#         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ local-definition
-#                                            ^ meta.fold.begin
+#         ^^^^^^^^^^ meta.toc-list entity.name.section
+#         @@@@@@@@@@ local-definition
+#                   ^ meta.fold.begin
 
   function Resolve-ConfigPath {
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.powershell meta.function.powershell


### PR DESCRIPTION
Technically regions [are only valid at BOL](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comments), but since they're not interpreted by Pwsh itself, we're being lenient.

See #216