### PR TITLE
Fix forward compatibility for rewritten C#

### DIFF
--- a/syntax/embed/C# (for PowerShell).sublime-syntax
+++ b/syntax/embed/C# (for PowerShell).sublime-syntax
@@ -9,31 +9,37 @@ extends: Packages/C#/C#.sublime-syntax
 contexts:
 
   inside_triple_quoted_raw_string_syntax:
+    # required before sublimehq/Packages/pull/4547
     - meta_include_prototype: false
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   inside_verbatim_string_syntax:
+    # required before sublimehq/Packages/pull/4547
     - meta_include_prototype: false
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   inside_verbatim_format_string_syntax:
+    # required before sublimehq/Packages/pull/4547
     - meta_include_prototype: false
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   inside-triple-quoted-raw-string-syntax:
+    # required for sublimehq/Packages/pull/4547
     - meta_include_prototype: false
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   inside-verbatim-string-syntax:
+    # required for sublimehq/Packages/pull/4547
     - meta_include_prototype: false
-    - match: ''
-      pop: 1
+    - include: immediately-pop
 
   inside-verbatim-format-string-syntax:
+    # required for sublimehq/Packages/pull/4547
+    - meta_include_prototype: false
+    - include: immediately-pop
+
+  immediately-pop:
+    # required before sublimehq/Packages/pull/4547
     - meta_include_prototype: false
     - match: ''
       pop: 1

--- a/syntax/embed/C# (for PowerShell).sublime-syntax
+++ b/syntax/embed/C# (for PowerShell).sublime-syntax
@@ -10,12 +10,30 @@ contexts:
 
   inside_triple_quoted_raw_string_syntax:
     - meta_include_prototype: false
-    - include: immediately_pop
+    - match: ''
+      pop: 1
 
   inside_verbatim_string_syntax:
     - meta_include_prototype: false
-    - include: immediately_pop
+    - match: ''
+      pop: 1
 
   inside_verbatim_format_string_syntax:
     - meta_include_prototype: false
-    - include: immediately_pop
+    - match: ''
+      pop: 1
+
+  inside-triple-quoted-raw-string-syntax:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 1
+
+  inside-verbatim-string-syntax:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 1
+
+  inside-verbatim-format-string-syntax:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 1


### PR DESCRIPTION
This PR adds renamed contexts to maintain compatibility with rewritten C# syntax.

Existing `immediately_pop` includes are replaced by explicit patterns to avoid missing context failures.

Alternatively a new `immediately-pop` context could be defined and included, which would then override the new one from rewritten C#.

caused by https://github.com/sublimehq/Packages/pull/4547